### PR TITLE
Improve match scheduling and match start handling

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -21,8 +21,18 @@ switch($action) {
         
     case 'generate_matches':
         $format = intval($_POST['format'] ?? 3);
-        generateMatches($format);
-        jsonResponse(['success' => true, 'matches' => getMatches()]);
+        $result = generateMatches($format);
+
+        if (!$result['success']) {
+            jsonResponse(['success' => false, 'message' => $result['message'] ?? 'Eroare la generarea meciurilor.']);
+        }
+
+        $response = ['success' => true, 'matches' => getMatches()];
+        if (!empty($result['warning'])) {
+            $response['warning'] = $result['warning'];
+        }
+
+        jsonResponse($response);
         break;
         
     case 'get_matches':
@@ -38,7 +48,12 @@ switch($action) {
 
     case 'start_match':
         $matchId = intval($_POST['match_id'] ?? 0);
-        startMatchById($matchId);
+        $result = startMatchById($matchId);
+
+        if (!$result['success']) {
+            jsonResponse(['success' => false, 'message' => $result['message'] ?? 'Nu am putut porni meciul.']);
+        }
+
         jsonResponse(['success' => true]);
         break;
 

--- a/script.js
+++ b/script.js
@@ -131,11 +131,22 @@ function generateMatches() {
     })
     .then(r => r.json())
     .then(data => {
-        if (data.success) {
-            alert('Meciuri generate cu succes!');
-            loadMatches();
-            switchView('matches');
+        if (!data.success) {
+            alert(data.message || 'Eroare la generarea meciurilor.');
+            return;
         }
+
+        let message = 'Meciuri generate cu succes!';
+        if (data.warning) {
+            message += `\n\n${data.warning}`;
+        }
+
+        alert(message);
+        loadMatches();
+        switchView('matches');
+    })
+    .catch(() => {
+        alert('Eroare la generarea meciurilor.');
     });
 }
 
@@ -208,9 +219,20 @@ function startMatch(matchId) {
         method: 'POST',
         body: formData
     })
-    .then(() => {
+    .then(r => r.json())
+    .then(data => {
+        if (!data.success) {
+            alert(data.message || 'Nu am putut porni meciul.');
+            currentMatchId = null;
+            return;
+        }
+
         switchView('live');
         loadMatches();
+    })
+    .catch(() => {
+        alert('Nu am putut porni meciul.');
+        currentMatchId = null;
     });
 }
 


### PR DESCRIPTION
## Summary
- add validation when starting a match so the API surfaces failures and the UI reports them
- rebuild the match generator to respect rest periods between matches and warn if the constraint cannot be satisfied
- surface scheduling warnings in the frontend and improve generate/start match error handling

## Testing
- php -l Scor/functions.php
- php -l Scor/ajax.php


------
https://chatgpt.com/codex/tasks/task_e_68e3e923ba448329beadb9c613bf6f60