### PR TITLE
Improve live match score display

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -327,10 +327,25 @@ nav {
     font-size: 64px;
 }
 
+.live-score .team-score small {
+    display: block;
+    margin-top: 8px;
+    color: rgba(249, 250, 251, 0.8);
+    text-align: center;
+    font-size: 14px;
+}
+
 .live-score .separator {
     font-size: 48px;
     font-weight: bold;
     color: #374151;
+}
+
+.sets-summary {
+    text-align: center;
+    font-weight: 600;
+    color: #374151;
+    margin-bottom: 20px;
 }
 
 .winner-banner {
@@ -345,6 +360,15 @@ nav {
 
 .sets-table {
     margin-bottom: 25px;
+}
+
+.sets-table table tr.set-current {
+    background: #eef2ff;
+    font-weight: 600;
+}
+
+.sets-table table tr.set-current td {
+    color: #1f2937;
 }
 
 .set-history {


### PR DESCRIPTION
## Summary
- adjust the live match renderer to track the active set even before the first rally and surface running points instead of set totals
- add a summary of sets won and clearer status messaging for live versus completed matches
- style the new live score details and highlight the in-progress set in the scoreboard table

## Testing
- not run (requires database connection/configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e3ec9cc7f083299871644f8fb59d93