### PR TITLE
Revamp live match scoreboard display

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -303,6 +303,258 @@ nav {
     color: #6b7280;
 }
 
+.scoreboard {
+    background: linear-gradient(160deg, #111827, #1f2937);
+    border-radius: 24px;
+    padding: 30px;
+    color: #f9fafb;
+    margin-bottom: 25px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+}
+
+.scoreboard-top-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+
+.set-box {
+    background: rgba(17, 24, 39, 0.9);
+    border-radius: 18px;
+    padding: 18px 28px;
+    min-width: 180px;
+    text-align: center;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.set-box.team1 {
+    border-top: 4px solid #3b82f6;
+}
+
+.set-box.team2 {
+    border-top: 4px solid #ef4444;
+}
+
+.set-box .set-value {
+    display: block;
+    font-size: 48px;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.set-box .set-label {
+    display: block;
+    margin-top: 6px;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(249, 250, 251, 0.7);
+}
+
+.scoreboard-center {
+    flex: 1;
+    text-align: center;
+}
+
+.scoreboard-center h2 {
+    font-size: 32px;
+    margin-bottom: 6px;
+}
+
+.scoreboard-center p {
+    margin-bottom: 4px;
+    color: rgba(249, 250, 251, 0.8);
+}
+
+.scoreboard-status-line {
+    font-weight: 600;
+    font-size: 15px;
+}
+
+.scoreboard-main {
+    display: flex;
+    gap: 20px;
+    margin-top: 24px;
+    flex-wrap: wrap;
+}
+
+.team-panel {
+    flex: 1;
+    min-width: 240px;
+    border-radius: 20px;
+    padding: 32px 28px;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    box-shadow: 0 20px 35px rgba(15, 23, 42, 0.4);
+}
+
+.team-panel.team1 {
+    background: linear-gradient(160deg, #3b82f6, #1d4ed8);
+}
+
+.team-panel.team2 {
+    background: linear-gradient(160deg, #ef4444, #b91c1c);
+}
+
+.team-panel .team-name {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.team-panel .team-points {
+    font-size: 96px;
+    line-height: 1;
+    font-weight: 800;
+}
+
+.team-panel .team-meta {
+    font-size: 14px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.btn-score {
+    margin-top: 8px;
+    padding: 14px 32px;
+    border-radius: 999px;
+    border: none;
+    font-weight: 700;
+    font-size: 16px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    background: rgba(255, 255, 255, 0.92);
+    color: #1d4ed8;
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.team-panel.team2 .btn-score {
+    color: #7f1d1d;
+}
+
+.btn-score:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.35);
+}
+
+.team-panel.winner {
+    box-shadow: 0 20px 45px rgba(16, 185, 129, 0.45);
+}
+
+.winner-tag {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    background: rgba(16, 185, 129, 0.95);
+    color: #ecfdf5;
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.points-timeline {
+    background: #f9fafb;
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: inset 0 0 0 1px #e5e7eb;
+}
+
+.points-timeline h3 {
+    margin-bottom: 18px;
+    color: #1f2937;
+}
+
+.set-timeline {
+    border-radius: 14px;
+    padding: 18px;
+    background: white;
+    margin-bottom: 16px;
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+}
+
+.set-timeline:last-child {
+    margin-bottom: 0;
+}
+
+.set-timeline-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+    font-weight: 700;
+    color: #111827;
+}
+
+.timeline-row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 10px;
+}
+
+.timeline-row:last-child {
+    margin-bottom: 0;
+}
+
+.team-label {
+    min-width: 140px;
+    font-weight: 600;
+    color: #374151;
+}
+
+.timeline-points {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.point-badge {
+    min-width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    font-weight: 700;
+    color: white;
+    box-shadow: 0 8px 15px rgba(107, 114, 128, 0.35);
+}
+
+.point-badge.team1 {
+    background: linear-gradient(160deg, #3b82f6, #1d4ed8);
+}
+
+.point-badge.team2 {
+    background: linear-gradient(160deg, #ef4444, #b91c1c);
+}
+
+.no-points {
+    color: #9ca3af;
+    font-style: italic;
+}
+
+.set-history-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+    font-weight: 600;
+    color: #1f2937;
+}
+
 .live-score {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- redesign the live match rendering to show a large dual-panel scoreboard with contextual status messaging
- highlight winners and build a detailed per-set timeline once matches are completed
- refresh stylesheet with new scoreboard, badge, and timeline components

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3eee5ce0c8329b0800192c952fc36