### PR TITLE
Restyle live match scoreboard UI

### DIFF
--- a/script.js
+++ b/script.js
@@ -387,30 +387,32 @@ function renderLiveMatch(data) {
 
     const scoreboard = `
         <div class="scoreboard">
-            <div class="scoreboard-top-bar">
-                <div class="set-box team1">
-                    <span class="set-value">${match.sets_team1}</span>
-                    <span class="set-label">Seturi ${match.team1_name}</span>
-                </div>
-                <div class="scoreboard-center">
+            <div class="scoreboard-header">
+                <div class="scoreboard-title">
                     <h2>${match.team1_name} vs ${match.team2_name}</h2>
-                    <p>Primul la ${setsToWin} seturi câștigate</p>
-                    <span class="scoreboard-status-line">${statusText}</span>
+                    <p>${statusText}</p>
+                    <span class="scoreboard-subtitle">Primul la ${setsToWin} seturi câștigate</span>
                 </div>
-                <div class="set-box team2">
-                    <span class="set-value">${match.sets_team2}</span>
-                    <span class="set-label">Seturi ${match.team2_name}</span>
+                <div class="scoreboard-sets">
+                    <div class="set-counter team1">
+                        <span class="set-label">Seturi ${match.team1_name}</span>
+                        <span class="set-value">${match.sets_team1}</span>
+                    </div>
+                    <div class="set-counter team2">
+                        <span class="set-label">Seturi ${match.team2_name}</span>
+                        <span class="set-value">${match.sets_team2}</span>
+                    </div>
                 </div>
             </div>
             <div class="scoreboard-main">
-                <div class="team-panel team1 ${team1Winner ? 'winner' : ''}">
+                <div class="team-card team1 ${team1Winner ? 'winner' : ''}">
                     ${team1WinnerTag}
                     <div class="team-name">${match.team1_name}</div>
                     <div class="team-points">${currentPointsTeam1}</div>
                     <div class="team-meta">${pointsLabel}</div>
                     ${!isCompleted ? `<button class="btn-score" onclick="addPointLive('team1')">+ Punct</button>` : ''}
                 </div>
-                <div class="team-panel team2 ${team2Winner ? 'winner' : ''}">
+                <div class="team-card team2 ${team2Winner ? 'winner' : ''}">
                     ${team2WinnerTag}
                     <div class="team-name">${match.team2_name}</div>
                     <div class="team-points">${currentPointsTeam2}</div>

--- a/styles.css
+++ b/styles.css
@@ -303,122 +303,145 @@ nav {
     color: #6b7280;
 }
 
+
 .scoreboard {
-    background: linear-gradient(160deg, #111827, #1f2937);
-    border-radius: 24px;
-    padding: 30px;
-    color: #f9fafb;
-    margin-bottom: 25px;
-    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
-}
-
-.scoreboard-top-bar {
+    background: #ffffff;
+    border-radius: 28px;
+    padding: 32px;
+    margin-bottom: 32px;
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.18);
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.scoreboard-header {
+    display: flex;
+    flex-direction: column;
     gap: 20px;
-    flex-wrap: wrap;
 }
 
-.set-box {
-    background: rgba(17, 24, 39, 0.9);
-    border-radius: 18px;
-    padding: 18px 28px;
-    min-width: 180px;
-    text-align: center;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+@media (min-width: 768px) {
+    .scoreboard-header {
+        flex-direction: row;
+        align-items: flex-end;
+        justify-content: space-between;
+    }
 }
 
-.set-box.team1 {
-    border-top: 4px solid #3b82f6;
-}
-
-.set-box.team2 {
-    border-top: 4px solid #ef4444;
-}
-
-.set-box .set-value {
-    display: block;
-    font-size: 48px;
-    font-weight: 700;
-    line-height: 1;
-}
-
-.set-box .set-label {
-    display: block;
-    margin-top: 6px;
-    font-size: 13px;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: rgba(249, 250, 251, 0.7);
-}
-
-.scoreboard-center {
-    flex: 1;
-    text-align: center;
-}
-
-.scoreboard-center h2 {
-    font-size: 32px;
+.scoreboard-title h2 {
+    font-size: 34px;
+    font-weight: 800;
+    color: #111827;
     margin-bottom: 6px;
 }
 
-.scoreboard-center p {
+.scoreboard-title p {
+    font-weight: 600;
+    color: #1f2937;
     margin-bottom: 4px;
-    color: rgba(249, 250, 251, 0.8);
+    line-height: 1.4;
 }
 
-.scoreboard-status-line {
-    font-weight: 600;
-    font-size: 15px;
+.scoreboard-subtitle {
+    display: inline-block;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 13px;
+    color: #6b7280;
+    margin-top: 6px;
+}
+
+.scoreboard-sets {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+@media (min-width: 768px) {
+    .scoreboard-sets {
+        justify-content: flex-end;
+    }
+}
+
+.set-counter {
+    min-width: 170px;
+    padding: 18px 24px;
+    border-radius: 20px;
+    color: #f9fafb;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    box-shadow: 0 18px 30px rgba(15, 23, 42, 0.25);
+}
+
+.set-counter.team1 {
+    background: linear-gradient(135deg, #1d4ed8, #1e3a8a);
+}
+
+.set-counter.team2 {
+    background: linear-gradient(135deg, #dc2626, #991b1b);
+}
+
+.set-counter .set-label {
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 12px;
+    color: rgba(249, 250, 251, 0.85);
+}
+
+.set-counter .set-value {
+    font-size: 44px;
+    font-weight: 800;
+    line-height: 1;
 }
 
 .scoreboard-main {
     display: flex;
-    gap: 20px;
-    margin-top: 24px;
+    gap: 24px;
     flex-wrap: wrap;
 }
 
-.team-panel {
+.team-card {
     flex: 1;
-    min-width: 240px;
-    border-radius: 20px;
-    padding: 32px 28px;
+    min-width: 260px;
+    border-radius: 28px;
+    padding: 36px 32px;
+    color: #ffffff;
     position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 14px;
-    box-shadow: 0 20px 35px rgba(15, 23, 42, 0.4);
+    box-shadow: 0 24px 45px rgba(15, 23, 42, 0.35);
 }
 
-.team-panel.team1 {
-    background: linear-gradient(160deg, #3b82f6, #1d4ed8);
+.team-card.team1 {
+    background: linear-gradient(150deg, #3b82f6, #1d4ed8);
 }
 
-.team-panel.team2 {
-    background: linear-gradient(160deg, #ef4444, #b91c1c);
+.team-card.team2 {
+    background: linear-gradient(150deg, #ef4444, #b91c1c);
 }
 
-.team-panel .team-name {
-    font-size: 22px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
+.team-card .team-name {
+    font-size: 24px;
+    font-weight: 800;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
 }
 
-.team-panel .team-points {
+.team-card .team-points {
     font-size: 96px;
     line-height: 1;
     font-weight: 800;
 }
 
-.team-panel .team-meta {
-    font-size: 14px;
-    letter-spacing: 0.05em;
+.team-card .team-meta {
+    font-size: 13px;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.85);
+    color: rgba(255, 255, 255, 0.9);
 }
 
 .btn-score {
@@ -437,8 +460,8 @@ nav {
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.team-panel.team2 .btn-score {
-    color: #7f1d1d;
+.team-card.team2 .btn-score {
+    color: #991b1b;
 }
 
 .btn-score:hover {
@@ -446,7 +469,7 @@ nav {
     box-shadow: 0 16px 30px rgba(15, 23, 42, 0.35);
 }
 
-.team-panel.winner {
+.team-card.winner {
     box-shadow: 0 20px 45px rgba(16, 185, 129, 0.45);
 }
 


### PR DESCRIPTION
## Summary
- redesign the live match scoreboard to use blue and red gradient panels similar to the provided mock-up
- refresh the set counters and header layout to better highlight the current status of the match

## Testing
- not run (PHP project without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e3f30a97b48329b702a5ea469d1ca0