### PR TITLE
Enhance live point history timeline

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -494,9 +494,24 @@ nav {
     box-shadow: inset 0 0 0 1px #e5e7eb;
 }
 
+.points-timeline.live {
+    background: #f8fafc;
+}
+
 .points-timeline h3 {
     margin-bottom: 18px;
     color: #1f2937;
+}
+
+.points-sections {
+    display: grid;
+    gap: 24px;
+}
+
+@media (min-width: 900px) {
+    .points-sections {
+        grid-template-columns: 1fr 1fr;
+    }
 }
 
 .set-timeline {
@@ -505,6 +520,11 @@ nav {
     background: white;
     margin-bottom: 16px;
     box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+}
+
+.set-timeline-live {
+    box-shadow: 0 14px 28px rgba(99, 102, 241, 0.22);
+    border: 2px dashed rgba(99, 102, 241, 0.35);
 }
 
 .set-timeline:last-child {
@@ -556,12 +576,26 @@ nav {
     box-shadow: 0 8px 15px rgba(107, 114, 128, 0.35);
 }
 
+
+.point-badge.latest {
+    position: relative;
+    transform: scale(1.08);
+}
+
+.point-badge.team1.latest {
+    box-shadow: 0 10px 22px rgba(59, 130, 246, 0.35);
+}
+
 .point-badge.team1 {
     background: linear-gradient(160deg, #3b82f6, #1d4ed8);
 }
 
 .point-badge.team2 {
     background: linear-gradient(160deg, #ef4444, #b91c1c);
+}
+
+.point-badge.team2.latest {
+    box-shadow: 0 10px 22px rgba(239, 68, 68, 0.35);
 }
 
 .no-points {


### PR DESCRIPTION
## Summary
- render the detailed point timeline during live matches with the same red/blue badges used for completed games
- highlight the active set and latest point while a match is in progress and keep the textual history alongside the timeline
- add responsive styling for the combined history/timeline layout and emphasize the newest point badge

## Testing
- not run (database connection details required for the PHP app)


------
https://chatgpt.com/codex/tasks/task_e_68e3fa0415ac8329b61d48b39181b0cd