### PR TITLE
Apply tournament tie-break rules to standings

### DIFF
--- a/script.js
+++ b/script.js
@@ -703,10 +703,13 @@ function loadStandings() {
                         <tr>
                             <th>#</th>
                             <th>Echipă</th>
+                            <th>Puncte Clasament</th>
                             <th>Victorii</th>
                             <th>Înfrângeri</th>
                             <th>Seturi (+/-)</th>
+                            <th>Raport Seturi</th>
                             <th>Puncte (+/-)</th>
+                            <th>Raport Puncte</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -714,10 +717,13 @@ function loadStandings() {
                             <tr>
                                 <td>${idx + 1}</td>
                                 <td>${team.name}</td>
+                                <td>${team.ranking_points}</td>
                                 <td>${team.wins}</td>
                                 <td>${team.losses}</td>
                                 <td>${team.sets_won}-${team.sets_lost}</td>
+                                <td>${team.set_ratio_display}</td>
                                 <td>${team.points_won}-${team.points_lost}</td>
+                                <td>${team.point_ratio_display}</td>
                             </tr>
                         `).join('')}
                     </tbody>


### PR DESCRIPTION
## Summary
- compute ranking points with the 2/1 scoring system and apply set/point ratio tie-breakers when sorting teams
- surface the ranking points and ratio details in the standings view so the ordering criteria are visible

## Testing
- php -l functions.php
- php -l ajax.php

------
https://chatgpt.com/codex/tasks/task_e_68e40a3598448329aa428a071e336acd