### PR TITLE
Add live match indicators and highlight completed games

### DIFF
--- a/script.js
+++ b/script.js
@@ -260,10 +260,15 @@ function loadMatches() {
             }
 
             container.innerHTML = data.matches.map((match, idx) => `
-                <div class="match-item ${match.status === 'completed' ? 'completed' : ''}">
+                <div class="match-item ${match.status === 'completed' ? 'completed' : ''} ${match.status === 'live' ? 'live' : ''}">
                     <div class="match-header">
                         <div class="match-info">
-                            <span style="color: #6b7280;">Meci #${match.match_order}</span>
+                            <div class="match-meta">
+                                <span class="match-number">Meci #${match.match_order}</span>
+                                <span class="match-status match-status-${match.status}">
+                                    ${match.status === 'live' ? 'În desfășurare' : (match.status === 'completed' ? 'Finalizat' : 'Programat')}
+                                </span>
+                            </div>
                             <h3>${match.team1_name} vs ${match.team2_name}</h3>
                             ${match.status === 'completed' ? `
                                 <div class="winner">Câștigător: ${match.winner_name} (${match.sets_team1}-${match.sets_team2})</div>

--- a/styles.css
+++ b/styles.css
@@ -194,8 +194,13 @@ nav {
 }
 
 .match-item.completed {
-    background: #d1fae5;
-    border-color: #10b981;
+    background: #fee2e2;
+    border-color: #ef4444;
+}
+
+.match-item.live {
+    background: #fff7ed;
+    border-color: #f97316;
 }
 
 .match-header {
@@ -209,8 +214,44 @@ nav {
     color: #1f2937;
 }
 
+.match-meta {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 6px;
+}
+
+.match-number {
+    color: #6b7280;
+}
+
+.match-status {
+    display: inline-flex;
+    align-items: center;
+    font-size: 14px;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 999px;
+    text-transform: uppercase;
+}
+
+.match-status-pending {
+    background: #e0e7ff;
+    color: #3730a3;
+}
+
+.match-status-live {
+    background: #ffedd5;
+    color: #c2410c;
+}
+
+.match-status-completed {
+    background: #fecaca;
+    color: #b91c1c;
+}
+
 .match-info .winner {
-    color: #10b981;
+    color: #b91c1c;
     font-weight: 600;
     margin-top: 5px;
 }


### PR DESCRIPTION
## Summary
- show the current status for each match in the schedule view
- highlight live matches and mark completed matches in red to emphasize that they are finished

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e40ecfae608329b762df7a372742d4