### PR TITLE
Adjust match status styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -199,8 +199,8 @@ nav {
 }
 
 .match-item.live {
-    background: #fff7ed;
-    border-color: #f97316;
+    background: #ecfdf5;
+    border-color: #22c55e;
 }
 
 .match-header {
@@ -230,24 +230,23 @@ nav {
     align-items: center;
     font-size: 14px;
     font-weight: 600;
-    padding: 4px 10px;
+    padding: 4px 12px;
     border-radius: 999px;
     text-transform: uppercase;
+    color: #ffffff;
+    letter-spacing: 0.08em;
 }
 
 .match-status-pending {
-    background: #e0e7ff;
-    color: #3730a3;
+    background: linear-gradient(135deg, #2563eb, #1d4ed8);
 }
 
 .match-status-live {
-    background: #ffedd5;
-    color: #c2410c;
+    background: linear-gradient(135deg, #22c55e, #16a34a);
 }
 
 .match-status-completed {
-    background: #fecaca;
-    color: #b91c1c;
+    background: linear-gradient(135deg, #ef4444, #dc2626);
 }
 
 .match-info .winner {


### PR DESCRIPTION
## Summary
- update live match cards to use a green border and refreshed background
- switch status badges to high-contrast blue, green, and red gradients with white text for readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4109dd020832984921326a68b47ad