### PR TITLE
Adjust live match timeline layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -439,24 +439,6 @@ function renderLiveMatch(data) {
         return acc;
     }, {});
 
-    const pointsHistoryMarkup = Object.keys(pointsBySet).length ? Object.entries(pointsBySet)
-        .map(([setNumber, setPoints]) => `
-            <div class="set-history">
-                <div class="set-history-header">
-                    <span>Set ${setNumber}</span>
-                    <span>${match.team1_name} ${setPoints[setPoints.length - 1]?.score_team1 ?? 0} - ${setPoints[setPoints.length - 1]?.score_team2 ?? 0} ${match.team2_name}</span>
-                </div>
-                <ul>
-                    ${setPoints.map(point => `
-                        <li>
-                            <strong>${point.scorer === 'team1' ? match.team1_name : match.team2_name}</strong>
-                            &ndash; scor ${point.score_team1}-${point.score_team2}
-                        </li>
-                    `).join('')}
-                </ul>
-            </div>
-        `).join('') : '<p>Încă nu au fost înregistrate puncte.</p>';
-
     const matchDurationInfo = buildDurationInfo(
         points[0]?.created_at || '',
         points.length ? points[points.length - 1].created_at : '',
@@ -612,23 +594,10 @@ function renderLiveMatch(data) {
                 </tbody>
             </table>
         </div>
-        ${isCompleted ? `
-            <div class="points-timeline">
-                <h3>Istoric puncte detaliat</h3>
-                ${timelineMarkup}
-            </div>
-        ` : `
-            <div class="points-sections">
-                <div class="points-history">
-                    <h3>Istoric puncte</h3>
-                    ${pointsHistoryMarkup}
-                </div>
-                <div class="points-timeline live">
-                    <h3>Istoric puncte detaliat</h3>
-                    ${timelineMarkup}
-                </div>
-            </div>
-        `}
+        <div class="points-timeline ${isCompleted ? '' : 'live'}">
+            <h3>Istoric puncte detaliat</h3>
+            ${timelineMarkup}
+        </div>
     `;
 
     scheduleLiveTimers(isCompleted);

--- a/styles.css
+++ b/styles.css
@@ -600,17 +600,6 @@ nav {
     color: #1f2937;
 }
 
-.points-sections {
-    display: grid;
-    gap: 24px;
-}
-
-@media (min-width: 900px) {
-    .points-sections {
-        grid-template-columns: 1fr 1fr;
-    }
-}
-
 .set-timeline {
     border-radius: 14px;
     padding: 18px;
@@ -869,57 +858,6 @@ nav {
     gap: 15px;
     justify-content: center;
     margin: 20px 0;
-}
-
-.points-history {
-    background: #f9fafb;
-    border-radius: 10px;
-    padding: 20px;
-    max-height: 300px;
-    overflow-y: auto;
-}
-
-.point-item {
-    display: flex;
-    justify-content: space-between;
-    padding: 8px 15px;
-    margin-bottom: 5px;
-    border-radius: 5px;
-}
-
-.point-item.blue {
-    background: #dbeafe;
-}
-
-.point-item.red {
-    background: #fee2e2;
-}
-
-.point-visual {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 15px;
-}
-
-.point-circle {
-    width: 35px;
-    height: 35px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: white;
-    font-weight: bold;
-    font-size: 12px;
-}
-
-.point-circle.blue {
-    background: #3b82f6;
-}
-
-.point-circle.red {
-    background: #ef4444;
 }
 
 .set-section {


### PR DESCRIPTION
## Summary
- display the live match detailed points timeline at full width and remove the redundant history column
- clean up unused point history styling left over from the old layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e414507fb08329b3ce878e99340140