### PR TITLE
Improve desktop scrolling for detailed point history

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -668,6 +668,25 @@ nav {
     grid-template-columns: repeat(var(--columns), minmax(34px, auto));
     gap: 8px;
     justify-items: center;
+    width: 100%;
+    overflow-x: auto;
+    padding-bottom: 6px;
+    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(107, 114, 128, 0.35) transparent;
+}
+
+.timeline-points::-webkit-scrollbar {
+    height: 8px;
+}
+
+.timeline-points::-webkit-scrollbar-thumb {
+    background: rgba(107, 114, 128, 0.35);
+    border-radius: 999px;
+}
+
+.timeline-points::-webkit-scrollbar-track {
+    background: transparent;
 }
 
 .point-badge {


### PR DESCRIPTION
## Summary
- allow the detailed points history grid to scroll horizontally on desktop layouts
- add subtle scrollbar styling to keep the component usable while scrolling

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e417a26f14832993be8e82cbbe8cf7