### PR TITLE
Add WhatsApp share option to standings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Aplicație web în PHP pentru organizarea și monitorizarea unui turneu de volei
 - Urmărire live a punctelor și seturilor, inclusiv istoric detaliat al fiecărui punct.
 - Clasament general cu actualizare automată a statisticilor (victorii, seturi/puncte câștigate/pierdute).
 - Export rapid al clasamentului în format imagine (folosind `html2canvas`).
+- Partajare instantă a clasamentului pe WhatsApp în format text.
+- Explicații integrate pentru regulile de calcul ale clasamentului.
 
 ## Structura proiectului
 ```

--- a/index.php
+++ b/index.php
@@ -74,10 +74,24 @@
         <div id="view-standings" class="view">
             <div class="card">
                 <h2>🏆 Clasament General</h2>
-                <button onclick="exportTable('standings-table', 'clasament')" class="btn btn-secondary mb-3">
-                    📸 Export JPG
-                </button>
-                <div id="standings-table"></div>
+                <div class="standings-actions">
+                    <button onclick="exportTable('standings-table', 'clasament')" class="btn btn-secondary">
+                        📸 Export JPG
+                    </button>
+                    <button onclick="shareStandingsWhatsApp()" class="btn btn-whatsapp">
+                        📤 Distribuie pe WhatsApp
+                    </button>
+                </div>
+                <div id="standings-table" class="standings-table"></div>
+                <div class="standings-info">
+                    <h3>ℹ️ Cum se calculează clasamentul</h3>
+                    <ul>
+                        <li><strong>Puncte clasament</strong>: fiecare victorie valorează 2 puncte, iar o înfrângere adaugă 1 punct pentru participare.</li>
+                        <li><strong>Raport seturi</strong>: seturile câștigate împărțite la seturile pierdute (∞ dacă nu ai pierdut niciun set).</li>
+                        <li><strong>Raport puncte</strong>: punctele câștigate împărțite la cele pierdute (∞ dacă nu ai pierdut niciun punct).</li>
+                        <li><strong>Departajare</strong>: se aplică în ordine – puncte clasament, raport seturi, raport puncte, diferență de seturi, diferență de puncte, apoi ordine alfabetică.</li>
+                    </ul>
+                </div>
             </div>
         </div>
 

--- a/styles.css
+++ b/styles.css
@@ -146,6 +146,15 @@ nav {
     color: white;
 }
 
+.btn-whatsapp {
+    background: #25d366;
+    color: #064420;
+}
+
+.btn-whatsapp:hover {
+    background: #1ebe5b;
+}
+
 .btn-danger {
     background: #ef4444;
     color: white;
@@ -1102,8 +1111,146 @@ table tr:nth-child(even) {
     background: #f9fafb;
 }
 
-table tr:first-child {
+table tbody tr:first-child {
     background: #fef3c7;
+}
+
+.standings-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.standings-table {
+    position: relative;
+}
+
+.standings-table-wrapper {
+    background: #f8fafc;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    overflow: hidden;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.standings-table table {
+    border-collapse: separate;
+    border-spacing: 0;
+}
+
+.standings-table thead th {
+    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    color: #ffffff;
+    font-size: 14px;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.standings-row {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.standings-row:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 25px rgba(79, 70, 229, 0.12);
+}
+
+.standings-gold {
+    background: linear-gradient(90deg, rgba(253, 230, 138, 0.65), rgba(250, 204, 21, 0.15));
+}
+
+.standings-silver {
+    background: linear-gradient(90deg, rgba(209, 213, 219, 0.6), rgba(148, 163, 184, 0.2));
+}
+
+.standings-bronze {
+    background: linear-gradient(90deg, rgba(252, 211, 77, 0.4), rgba(217, 119, 6, 0.12));
+}
+
+.standings-rank {
+    width: 70px;
+}
+
+.rank-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: white;
+    border: 2px solid rgba(99, 102, 241, 0.4);
+    font-weight: 700;
+    color: #4338ca;
+    box-shadow: 0 4px 12px rgba(79, 70, 229, 0.2);
+}
+
+.standings-team {
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.points-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(79, 70, 229, 0.1);
+    color: #4338ca;
+    font-weight: 700;
+    font-size: 14px;
+}
+
+.stat-line {
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+}
+
+.stat-line-main {
+    font-weight: 600;
+    color: #111827;
+}
+
+.stat-line-diff {
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 6px;
+    background: rgba(148, 163, 184, 0.15);
+    color: #475569;
+}
+
+.stat-line-diff.positive {
+    background: rgba(16, 185, 129, 0.12);
+    color: #047857;
+}
+
+.stat-line-diff.negative {
+    background: rgba(239, 68, 68, 0.12);
+    color: #b91c1c;
+}
+
+.standings-info {
+    margin-top: 24px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 12px;
+    padding: 20px 24px;
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+}
+
+.standings-info h3 {
+    margin-bottom: 12px;
+    color: #4338ca;
+}
+
+.standings-info ul {
+    list-style: disc;
+    margin-left: 20px;
+    color: #1f2937;
+    line-height: 1.6;
 }
 
 .text-center {


### PR DESCRIPTION
## Summary
- add a WhatsApp sharing flow and reusable export helper for the standings table
- restyle the standings table with medal highlights and compact stat lines
- document the ranking rules directly in the UI and README

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68e4a2bde9388329ab90f382742cf9bc