### PR TITLE
Add JPG export and WhatsApp sharing for standings

### DIFF
--- a/index.php
+++ b/index.php
@@ -75,7 +75,7 @@
             <div class="card">
                 <h2>🏆 Clasament General</h2>
                 <div class="standings-actions">
-                    <button onclick="exportTable('standings-table', 'clasament')" class="btn btn-secondary">
+                    <button onclick="exportStandingsImage()" class="btn btn-secondary">
                         📸 Export JPG
                     </button>
                     <button onclick="shareStandingsWhatsApp()" class="btn btn-whatsapp">

--- a/styles.css
+++ b/styles.css
@@ -1122,6 +1122,14 @@ table tbody tr:first-child {
     margin-bottom: 20px;
 }
 
+.standings-export-mode .standings-actions {
+    display: none !important;
+}
+
+.standings-export-mode {
+    position: relative;
+}
+
 .standings-table {
     position: relative;
 }


### PR DESCRIPTION
## Summary
- update the standings export button to use a new helper that captures the entire standings card as a JPG
- add WhatsApp sharing support that prefers the Web Share API with a generated image and falls back to the existing text share
- hide the action buttons while capturing the standings card to produce a cleaner export

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4a5ca7edc8329b30c6573d6eb9bdd