### PR TITLE
Improve detailed points timeline responsiveness

### DIFF
--- a/script.js
+++ b/script.js
@@ -459,7 +459,7 @@ function renderLiveMatch(data) {
         !isCompleted ? currentSetNumber : null
     ].filter(Boolean))).sort((a, b) => a - b);
 
-    const timelineMarkup = setNumbers.length ? setNumbers.map(setNumber => {
+    const timelineSetsMarkup = setNumbers.length ? setNumbers.map(setNumber => {
         const setDetails = sortedSets.find(set => Number(set.set_number) === setNumber) || null;
         const setPoints = (pointsBySet[setNumber] || []).slice().sort((a, b) => Number(a.point_number) - Number(b.point_number));
         const highlightActive = !isCompleted && setNumber === currentSetNumber;
@@ -479,7 +479,7 @@ function renderLiveMatch(data) {
                 <div class="set-timeline ${highlightActive ? 'set-timeline-live' : ''}">
                     <div class="set-timeline-header">
                         <span class="set-title">Set ${setNumber}</span>
-                        <span class="set-score">${displayScoreTeam1}-${displayScoreTeam2}</span>
+                        <div class="set-score">${displayScoreTeam1}<span>-</span>${displayScoreTeam2}</div>
                         <span class="set-duration" ${durationAttrs}>⏱️ --:--</span>
                     </div>
                     <p class="timeline-empty">Încă nu s-au marcat puncte în acest set.</p>
@@ -513,20 +513,32 @@ function renderLiveMatch(data) {
             <div class="set-timeline ${highlightActive ? 'set-timeline-live' : ''}">
                 <div class="set-timeline-header">
                     <span class="set-title">Set ${setNumber}</span>
-                    <span class="set-score">${displayScoreTeam1}-${displayScoreTeam2}</span>
+                    <div class="set-score">${displayScoreTeam1}<span>-</span>${displayScoreTeam2}</div>
                     <span class="set-duration" ${durationAttrs}>${durationText}</span>
                 </div>
-                <div class="timeline-row">
+                <div class="timeline-row team1-row">
                     <span class="team-label">${match.team1_name}</span>
                     <div class="timeline-points"${gridColumnsStyle}>${team1Badges}</div>
                 </div>
-                <div class="timeline-row">
+                <div class="timeline-row team2-row">
                     <span class="team-label">${match.team2_name}</span>
                     <div class="timeline-points"${gridColumnsStyle}>${team2Badges}</div>
                 </div>
             </div>
         `;
-    }).join('') : '<p>Nu există date pentru acest meci.</p>';
+    }).join('') : '';
+
+    const timelineMarkup = timelineSetsMarkup
+        ? `
+            <div class="points-timeline-content">
+                <div class="timeline-legend" aria-label="Legendă culori echipe">
+                    <span class="legend-item"><span class="legend-dot team1"></span>${match.team1_name}</span>
+                    <span class="legend-item"><span class="legend-dot team2"></span>${match.team2_name}</span>
+                </div>
+                <div class="timeline-sets">${timelineSetsMarkup}</div>
+            </div>
+        `
+        : '<p class="timeline-empty">Nu există date pentru acest meci.</p>';
 
     const scoreboard = `
         <div class="scoreboard">

--- a/styles.css
+++ b/styles.css
@@ -594,36 +594,86 @@ nav {
 }
 
 .points-timeline {
-    background: #f9fafb;
-    border-radius: 16px;
-    padding: 24px;
-    box-shadow: inset 0 0 0 1px #e5e7eb;
+    background: radial-gradient(circle at top, rgba(30, 64, 175, 0.18), rgba(15, 23, 42, 0.94));
+    border-radius: 24px;
+    padding: 28px;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+    color: #e2e8f0;
 }
 
 .points-timeline.live {
-    background: #f8fafc;
+    box-shadow: inset 0 0 0 2px rgba(129, 140, 248, 0.45);
 }
 
 .points-timeline h3 {
-    margin-bottom: 18px;
-    color: #1f2937;
+    margin-bottom: 20px;
+    font-size: 22px;
+    color: #f8fafc;
+    text-align: center;
 }
 
-.set-timeline { 
-    border-radius: 14px;
-    padding: 18px;
-    background: white;
-    margin-bottom: 16px;
-    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+.points-timeline-content {
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+}
+
+.timeline-legend {
+    display: flex;
+    justify-content: center;
+    gap: 24px;
+    flex-wrap: wrap;
+    font-size: 14px;
+    color: rgba(226, 232, 240, 0.85);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.6);
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.legend-dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.legend-dot.team1 {
+    background: linear-gradient(135deg, #60a5fa, #1d4ed8);
+}
+
+.legend-dot.team2 {
+    background: linear-gradient(135deg, #f87171, #b91c1c);
+}
+
+.timeline-sets {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+}
+
+.set-timeline {
+    border-radius: 22px;
+    padding: 22px;
+    background: rgba(15, 23, 42, 0.7);
+    box-shadow: 0 24px 40px rgba(15, 23, 42, 0.35);
+    backdrop-filter: blur(6px);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
 }
 
 .set-timeline-live {
-    box-shadow: 0 14px 28px rgba(99, 102, 241, 0.22);
-    border: 2px dashed rgba(99, 102, 241, 0.35);
-}
-
-.set-timeline:last-child {
-    margin-bottom: 0;
+    box-shadow: 0 28px 50px rgba(99, 102, 241, 0.4);
+    border: 2px solid rgba(99, 102, 241, 0.5);
 }
 
 .set-timeline-header {
@@ -631,53 +681,93 @@ nav {
     grid-template-columns: 1fr auto auto;
     align-items: center;
     gap: 12px;
-    margin-bottom: 12px;
     font-weight: 700;
-    color: #111827;
+    color: #f8fafc;
+}
+
+.set-timeline-live .set-timeline-header {
+    color: #eef2ff;
 }
 
 .set-title {
     font-weight: 700;
+    letter-spacing: 0.06em;
 }
 
 .set-score {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    font-size: 24px;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+}
+
+.set-score span {
+    opacity: 0.6;
     font-size: 18px;
 }
 
 .set-duration {
     font-size: 12px;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
-    color: #6b7280;
-    display: flex;
+    color: rgba(226, 232, 240, 0.7);
+    display: inline-flex;
     align-items: center;
     gap: 6px;
 }
 
 .timeline-row {
     display: flex;
-    align-items: flex-start;
-    gap: 16px;
-    margin-bottom: 10px;
+    align-items: center;
+    gap: 14px;
 }
 
-.timeline-row:last-child {
-    margin-bottom: 0;
+.timeline-row + .timeline-row {
+    margin-top: 6px;
 }
 
 .team-label {
-    min-width: 140px;
-    font-weight: 600;
-    color: #374151;
+    flex-shrink: 0;
+    min-width: 120px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    font-weight: 700;
+    font-size: 13px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    background: rgba(59, 130, 246, 0.18);
+    color: #bfdbfe;
+    text-align: center;
+}
+
+.timeline-row.team2-row .team-label {
+    background: rgba(248, 113, 113, 0.22);
+    color: #fecaca;
 }
 
 .timeline-points {
-    --badge-size: clamp(32px, 6vw, 46px);
+    --badge-size: clamp(30px, 5.5vw, 44px);
+    --columns: auto-fit;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(var(--badge-size), 1fr));
+    grid-template-columns: repeat(var(--columns, auto-fit), minmax(var(--badge-size), 1fr));
     gap: 8px;
+    align-items: center;
     justify-items: center;
     width: 100%;
+    padding: 4px 0;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+}
+
+.timeline-points::-webkit-scrollbar {
+    height: 6px;
+}
+
+.timeline-points::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.4);
+    border-radius: 999px;
 }
 
 .point-badge {
@@ -691,7 +781,7 @@ nav {
     font-size: 14px;
     font-weight: 700;
     color: white;
-    box-shadow: 0 8px 15px rgba(107, 114, 128, 0.35);
+    box-shadow: 0 14px 28px rgba(15, 23, 42, 0.45);
 }
 
 .point-badge.placeholder {
@@ -710,6 +800,22 @@ nav {
 
 .point-badge.team1.latest {
     box-shadow: 0 10px 22px rgba(59, 130, 246, 0.35);
+}
+
+@media (max-width: 1024px) {
+    .timeline-sets {
+        display: flex;
+        gap: 18px;
+        overflow-x: auto;
+        padding-bottom: 10px;
+        scroll-snap-type: x proximity;
+    }
+
+    .timeline-sets .set-timeline {
+        min-width: min(320px, 85vw);
+        flex: 0 0 auto;
+        scroll-snap-align: start;
+    }
 }
 
 @media (max-width: 768px) {
@@ -734,12 +840,12 @@ nav {
     }
 
     .set-timeline {
-        padding: 16px;
+        padding: 18px;
     }
 
     .set-timeline-header {
         grid-template-columns: 1fr;
-        gap: 8px;
+        gap: 6px;
     }
 
     .set-timeline-header .set-score,
@@ -749,22 +855,17 @@ nav {
 
     .timeline-row {
         flex-direction: column;
-        align-items: flex-start;
-        gap: 8px;
+        align-items: stretch;
+        gap: 10px;
     }
 
     .team-label {
         min-width: 0;
-        font-size: 14px;
     }
 
     .timeline-points {
-        --badge-size: clamp(28px, 9vw, 40px);
-        grid-template-columns: repeat(auto-fit, minmax(var(--badge-size), 1fr));
-    }
-
-    .point-badge {
-        margin: 0 auto;
+        --badge-size: clamp(32px, 11vw, 46px);
+        grid-template-columns: repeat(var(--columns, auto-fit), minmax(var(--badge-size), 1fr));
     }
 }
 
@@ -788,7 +889,8 @@ nav {
 .timeline-empty {
     margin: 0;
     font-style: italic;
-    color: #6b7280;
+    text-align: center;
+    color: rgba(226, 232, 240, 0.75);
 }
 
 .set-history-header {


### PR DESCRIPTION
## Summary
- restructure the live match timeline markup to include a legend and per-set cards for point badges
- refresh the detailed points timeline styling to match the desired scoreboard layout and improve readability
- add responsive behavior so the timeline scrolls horizontally on smaller viewports

## Testing
- not run (UI-only)


------
https://chatgpt.com/codex/tasks/task_e_68e4b490fbb483299e89e62e084602e0