### PR TITLE
Lighten scoreboard palette and improve timeline layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,7 @@
 
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(160deg, #eef2ff 0%, #f8fafc 100%);
     min-height: 100vh;
     padding: 20px;
 }
@@ -17,16 +17,17 @@ body {
 }
 
 header {
-    background: white;
+    background: rgba(255, 255, 255, 0.92);
     border-radius: 15px;
     padding: 20px;
     margin-bottom: 20px;
-    box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+    border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 header h1 {
     text-align: center;
-    color: #667eea;
+    color: #3b82f6;
     margin-bottom: 15px;
 }
 
@@ -39,9 +40,9 @@ nav {
 
 .nav-btn {
     padding: 10px 20px;
-    border: 2px solid #667eea;
+    border: 2px solid rgba(59, 130, 246, 0.4);
     background: white;
-    color: #667eea;
+    color: #2563eb;
     border-radius: 8px;
     cursor: pointer;
     font-weight: 600;
@@ -49,12 +50,13 @@ nav {
 }
 
 .nav-btn:hover {
-    background: #f0f4ff;
+    background: #eff6ff;
 }
 
 .nav-btn.active {
-    background: #667eea;
+    background: linear-gradient(135deg, #60a5fa, #2563eb);
     color: white;
+    border-color: transparent;
 }
 
 .view {
@@ -354,14 +356,15 @@ nav {
 
 
 .scoreboard {
-    background: #ffffff;
+    background: rgba(255, 255, 255, 0.95);
     border-radius: 28px;
     padding: 32px;
     margin-bottom: 32px;
-    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.18);
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.14);
     display: flex;
     flex-direction: column;
     gap: 28px;
+    border: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .scoreboard-header {
@@ -417,19 +420,23 @@ nav {
     min-width: 170px;
     padding: 18px 24px;
     border-radius: 20px;
-    color: #f9fafb;
+    color: #1f2937;
     display: flex;
     flex-direction: column;
     gap: 8px;
-    box-shadow: 0 18px 30px rgba(15, 23, 42, 0.25);
+    box-shadow: 0 18px 30px rgba(148, 163, 184, 0.25);
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.95), rgba(226, 232, 240, 0.85));
+    border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .set-counter.team1 {
-    background: linear-gradient(135deg, #1d4ed8, #1e3a8a);
+    background: linear-gradient(135deg, #bfdbfe, #93c5fd);
+    color: #1e3a8a;
 }
 
 .set-counter.team2 {
-    background: linear-gradient(135deg, #dc2626, #991b1b);
+    background: linear-gradient(135deg, #fecaca, #fda4af);
+    color: #7f1d1d;
 }
 
 .set-counter .set-label {
@@ -647,33 +654,34 @@ nav {
 }
 
 .legend-dot.team1 {
-    background: linear-gradient(135deg, #60a5fa, #1d4ed8);
+    background: linear-gradient(135deg, #bfdbfe, #60a5fa);
 }
 
 .legend-dot.team2 {
-    background: linear-gradient(135deg, #f87171, #b91c1c);
+    background: linear-gradient(135deg, #fecaca, #f87171);
 }
 
 .timeline-sets {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    display: flex;
+    flex-direction: column;
     gap: 20px;
 }
 
 .set-timeline {
     border-radius: 22px;
     padding: 22px;
-    background: rgba(15, 23, 42, 0.7);
-    box-shadow: 0 24px 40px rgba(15, 23, 42, 0.35);
-    backdrop-filter: blur(6px);
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(226, 232, 240, 0.9));
+    box-shadow: 0 20px 36px rgba(148, 163, 184, 0.28);
+    backdrop-filter: blur(4px);
     display: flex;
     flex-direction: column;
     gap: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .set-timeline-live {
-    box-shadow: 0 28px 50px rgba(99, 102, 241, 0.4);
-    border: 2px solid rgba(99, 102, 241, 0.5);
+    box-shadow: 0 28px 50px rgba(99, 102, 241, 0.25);
+    border: 2px solid rgba(99, 102, 241, 0.25);
 }
 
 .set-timeline-header {
@@ -682,11 +690,11 @@ nav {
     align-items: center;
     gap: 12px;
     font-weight: 700;
-    color: #f8fafc;
+    color: #1f2937;
 }
 
 .set-timeline-live .set-timeline-header {
-    color: #eef2ff;
+    color: #1d4ed8;
 }
 
 .set-title {
@@ -701,18 +709,20 @@ nav {
     font-size: 24px;
     font-weight: 800;
     font-variant-numeric: tabular-nums;
+    color: #111827;
 }
 
 .set-score span {
     opacity: 0.6;
     font-size: 18px;
+    color: #475569;
 }
 
 .set-duration {
     font-size: 12px;
     letter-spacing: 0.1em;
     text-transform: uppercase;
-    color: rgba(226, 232, 240, 0.7);
+    color: rgba(71, 85, 105, 0.7);
     display: inline-flex;
     align-items: center;
     gap: 6px;
@@ -720,7 +730,7 @@ nav {
 
 .timeline-row {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 14px;
 }
 
@@ -737,28 +747,27 @@ nav {
     font-size: 13px;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    background: rgba(59, 130, 246, 0.18);
-    color: #bfdbfe;
+    background: rgba(191, 219, 254, 0.6);
+    color: #1d4ed8;
     text-align: center;
 }
 
 .timeline-row.team2-row .team-label {
-    background: rgba(248, 113, 113, 0.22);
-    color: #fecaca;
+    background: rgba(254, 202, 202, 0.6);
+    color: #b91c1c;
 }
 
 .timeline-points {
-    --badge-size: clamp(30px, 5.5vw, 44px);
-    --columns: auto-fit;
+    --badge-size: clamp(34px, 5.5vw, 48px);
+    --columns: auto-fill;
     display: grid;
-    grid-template-columns: repeat(var(--columns, auto-fit), minmax(var(--badge-size), 1fr));
-    gap: 8px;
+    grid-template-columns: repeat(var(--columns, auto-fill), minmax(var(--badge-size), 1fr));
+    gap: 10px;
     align-items: center;
     justify-items: center;
     width: 100%;
-    padding: 4px 0;
-    overflow-x: auto;
-    overscroll-behavior-inline: contain;
+    padding: 6px 0;
+    overflow: hidden;
 }
 
 .timeline-points::-webkit-scrollbar {
@@ -781,7 +790,7 @@ nav {
     font-size: 14px;
     font-weight: 700;
     color: white;
-    box-shadow: 0 14px 28px rgba(15, 23, 42, 0.45);
+    box-shadow: 0 12px 24px rgba(148, 163, 184, 0.35);
 }
 
 .point-badge.placeholder {
@@ -799,22 +808,16 @@ nav {
 }
 
 .point-badge.team1.latest {
-    box-shadow: 0 10px 22px rgba(59, 130, 246, 0.35);
+    box-shadow: 0 10px 22px rgba(96, 165, 250, 0.4);
 }
 
 @media (max-width: 1024px) {
     .timeline-sets {
-        display: flex;
         gap: 18px;
-        overflow-x: auto;
-        padding-bottom: 10px;
-        scroll-snap-type: x proximity;
     }
 
     .timeline-sets .set-timeline {
-        min-width: min(320px, 85vw);
-        flex: 0 0 auto;
-        scroll-snap-align: start;
+        min-width: 0;
     }
 }
 
@@ -864,21 +867,21 @@ nav {
     }
 
     .timeline-points {
-        --badge-size: clamp(32px, 11vw, 46px);
-        grid-template-columns: repeat(var(--columns, auto-fit), minmax(var(--badge-size), 1fr));
+        --badge-size: clamp(32px, 12vw, 46px);
+        grid-template-columns: repeat(var(--columns, auto-fill), minmax(var(--badge-size), 1fr));
     }
 }
 
 .point-badge.team1 {
-    background: linear-gradient(160deg, #3b82f6, #1d4ed8);
+    background: linear-gradient(160deg, #93c5fd, #3b82f6);
 }
 
 .point-badge.team2 {
-    background: linear-gradient(160deg, #ef4444, #b91c1c);
+    background: linear-gradient(160deg, #fda4af, #f87171);
 }
 
 .point-badge.team2.latest {
-    box-shadow: 0 10px 22px rgba(239, 68, 68, 0.35);
+    box-shadow: 0 10px 22px rgba(248, 113, 113, 0.4);
 }
 
 .no-points {


### PR DESCRIPTION
## Summary
- refresh the global and live match scoreboard styling with a lighter palette and softer shadows
- restyle set counters, timeline cards, and point badges with pastel gradients for improved readability
- stack set timelines vertically and tighten point badge grid behavior for better desktop and mobile alignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4c31016ec8329a3f67db5f8013faf