### PR TITLE
Improve mobile point history layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -472,8 +472,6 @@ function renderLiveMatch(data) {
         const durationText = `⏱️ ${durationInfo.display}`;
         const displayScoreTeam1 = Number(setDetails?.score_team1 ?? (setPoints[totalColumns - 1]?.score_team1 ?? 0));
         const displayScoreTeam2 = Number(setDetails?.score_team2 ?? (setPoints[totalColumns - 1]?.score_team2 ?? 0));
-        const gridColumnsStyle = totalColumns ? ` style="--columns:${totalColumns}"` : '';
-
         if (!totalColumns) {
             return `
                 <div class="set-timeline ${highlightActive ? 'set-timeline-live' : ''}">
@@ -487,26 +485,17 @@ function renderLiveMatch(data) {
             `;
         }
 
-        const team1Badges = setPoints.map((point, idx) => {
-            if (point.scorer === 'team1') {
-                const badgeClasses = ['point-badge', 'team1'];
-                if (highlightActive && idx === latestIndex) {
-                    badgeClasses.push('latest');
-                }
-                return `<span class="${badgeClasses.join(' ')}">${point.score_team1}</span>`;
+        const sequenceBadges = setPoints.map((point, idx) => {
+            const scorerClass = point.scorer === 'team1' ? 'team1' : 'team2';
+            const badgeClasses = ['point-badge', scorerClass];
+            if (highlightActive && idx === latestIndex) {
+                badgeClasses.push('latest');
             }
-            return '<span class="point-badge placeholder"></span>';
-        }).join('');
-
-        const team2Badges = setPoints.map((point, idx) => {
-            if (point.scorer === 'team2') {
-                const badgeClasses = ['point-badge', 'team2'];
-                if (highlightActive && idx === latestIndex) {
-                    badgeClasses.push('latest');
-                }
-                return `<span class="${badgeClasses.join(' ')}">${point.score_team2}</span>`;
-            }
-            return '<span class="point-badge placeholder"></span>';
+            const displayScoreTeam1 = Number(point.score_team1 || 0);
+            const displayScoreTeam2 = Number(point.score_team2 || 0);
+            const scoreLabel = `${displayScoreTeam1}-${displayScoreTeam2}`;
+            const tooltip = `${match.team1_name} ${displayScoreTeam1} - ${match.team2_name} ${displayScoreTeam2}`;
+            return `<span class="${badgeClasses.join(' ')}" title="${tooltip}">${scoreLabel}</span>`;
         }).join('');
 
         return `
@@ -516,14 +505,11 @@ function renderLiveMatch(data) {
                     <div class="set-score">${displayScoreTeam1}<span>-</span>${displayScoreTeam2}</div>
                     <span class="set-duration" ${durationAttrs}>${durationText}</span>
                 </div>
-                <div class="timeline-row team1-row">
-                    <span class="team-label">${match.team1_name}</span>
-                    <div class="timeline-points"${gridColumnsStyle}>${team1Badges}</div>
+                <div class="timeline-team-info">
+                    <span class="team-label"><span class="team-dot team1"></span>${match.team1_name}</span>
+                    <span class="team-label"><span class="team-dot team2"></span>${match.team2_name}</span>
                 </div>
-                <div class="timeline-row team2-row">
-                    <span class="team-label">${match.team2_name}</span>
-                    <div class="timeline-points"${gridColumnsStyle}>${team2Badges}</div>
-                </div>
+                <div class="timeline-sequence">${sequenceBadges}</div>
             </div>
         `;
     }).join('') : '';
@@ -1004,31 +990,22 @@ function loadStats() {
                         ? set.points.slice().sort((a, b) => Number(a.point_number) - Number(b.point_number))
                         : [];
                     const totalColumns = points.length;
-                    const gridColumnsStyle = totalColumns ? ` style="--columns:${totalColumns}"` : '';
 
-                    const team1Badges = points.map(point => {
-                        if (point.scorer === 'team1') {
-                            return `<span class="point-badge team1">${point.score_team1}</span>`;
-                        }
-                        return '<span class="point-badge placeholder"></span>';
-                    }).join('');
-
-                    const team2Badges = points.map(point => {
-                        if (point.scorer === 'team2') {
-                            return `<span class="point-badge team2">${point.score_team2}</span>`;
-                        }
-                        return '<span class="point-badge placeholder"></span>';
+                    const sequenceBadges = points.map(point => {
+                        const scorerClass = point.scorer === 'team1' ? 'team1' : 'team2';
+                        const displayScoreTeam1 = Number(point.score_team1 || 0);
+                        const displayScoreTeam2 = Number(point.score_team2 || 0);
+                        const scoreLabel = `${displayScoreTeam1}-${displayScoreTeam2}`;
+                        const tooltip = `${match.team1_name} ${displayScoreTeam1} - ${match.team2_name} ${displayScoreTeam2}`;
+                        return `<span class="point-badge ${scorerClass}" title="${tooltip}">${scoreLabel}</span>`;
                     }).join('');
 
                     const pointsMarkup = totalColumns ? `
-                        <div class="timeline-row">
-                            <span class="team-label">${match.team1_name}</span>
-                            <div class="timeline-points"${gridColumnsStyle}>${team1Badges}</div>
+                        <div class="timeline-team-info">
+                            <span class="team-label"><span class="team-dot team1"></span>${match.team1_name}</span>
+                            <span class="team-label"><span class="team-dot team2"></span>${match.team2_name}</span>
                         </div>
-                        <div class="timeline-row">
-                            <span class="team-label">${match.team2_name}</span>
-                            <div class="timeline-points"${gridColumnsStyle}>${team2Badges}</div>
-                        </div>
+                        <div class="timeline-sequence">${sequenceBadges}</div>
                     ` : '<p class="empty-points">Nu sunt puncte înregistrate pentru acest set.</p>';
 
                     return `

--- a/styles.css
+++ b/styles.css
@@ -728,55 +728,49 @@ nav {
     gap: 6px;
 }
 
-.timeline-row {
+.timeline-team-info {
     display: flex;
-    align-items: flex-start;
-    gap: 14px;
-}
-
-.timeline-row + .timeline-row {
-    margin-top: 6px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
 }
 
 .team-label {
-    flex-shrink: 0;
-    min-width: 120px;
-    padding: 8px 14px;
-    border-radius: 999px;
-    font-weight: 700;
-    font-size: 13px;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    background: rgba(191, 219, 254, 0.6);
-    color: #1d4ed8;
-    text-align: center;
-}
-
-.timeline-row.team2-row .team-label {
-    background: rgba(254, 202, 202, 0.6);
-    color: #b91c1c;
-}
-
-.timeline-points {
-    --badge-size: clamp(34px, 5.5vw, 48px);
-    --columns: auto-fill;
-    display: grid;
-    grid-template-columns: repeat(var(--columns, auto-fill), minmax(var(--badge-size), 1fr));
+    display: inline-flex;
+    align-items: center;
     gap: 10px;
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #1f2937;
+}
+
+.team-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    display: inline-block;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.7);
+}
+
+.team-dot.team1 {
+    background: linear-gradient(160deg, #93c5fd, #3b82f6);
+}
+
+.team-dot.team2 {
+    background: linear-gradient(160deg, #fda4af, #f87171);
+}
+
+.timeline-sequence {
+    --badge-size: clamp(46px, 12vw, 60px);
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(var(--badge-size), 1fr));
+    gap: 12px;
     align-items: center;
     justify-items: center;
     width: 100%;
-    padding: 6px 0;
-    overflow: hidden;
-}
-
-.timeline-points::-webkit-scrollbar {
-    height: 6px;
-}
-
-.timeline-points::-webkit-scrollbar-thumb {
-    background: rgba(148, 163, 184, 0.4);
-    border-radius: 999px;
 }
 
 .point-badge {
@@ -787,8 +781,9 @@ nav {
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 14px;
+    font-size: 13px;
     font-weight: 700;
+    font-variant-numeric: tabular-nums;
     color: white;
     box-shadow: 0 12px 24px rgba(148, 163, 184, 0.35);
 }
@@ -856,19 +851,15 @@ nav {
         justify-self: flex-start;
     }
 
-    .timeline-row {
+    .timeline-team-info {
         flex-direction: column;
-        align-items: stretch;
-        gap: 10px;
+        align-items: flex-start;
+        gap: 8px;
     }
 
-    .team-label {
-        min-width: 0;
-    }
-
-    .timeline-points {
-        --badge-size: clamp(32px, 12vw, 46px);
-        grid-template-columns: repeat(var(--columns, auto-fill), minmax(var(--badge-size), 1fr));
+    .timeline-sequence {
+        --badge-size: clamp(44px, 18vw, 58px);
+        grid-template-columns: repeat(auto-fit, minmax(var(--badge-size), 1fr));
     }
 }
 


### PR DESCRIPTION
## Summary
- replace split-row point history markup with a single unified sequence of coloured badges
- add compact team colour indicators so the scorer is identifiable without leaving gaps on mobile
- tweak responsive styles so the point timeline wraps cleanly on smaller screens

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4c8d04f948329ae5b990d54c7f341