### PR TITLE
Add configurable title and improve mobile badges

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@
 <body>
     <div class="container">
         <header>
-            <h1>🏐 Manager Turneu Volei</h1>
+            <h1 id="app-title">🏐 Manager Turneu Volei</h1>
             <nav>
                 <button class="nav-btn active" data-view="setup">⚙️ Setup</button>
                 <button class="nav-btn" data-view="matches">📋 Meciuri</button>
@@ -31,6 +31,16 @@
                         <label><input type="radio" name="format" value="3" checked> Best of 3</label>
                         <label><input type="radio" name="format" value="5"> Best of 5</label>
                     </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="app-title-input">Titlu aplicație:</label>
+                    <div class="input-group">
+                        <input type="text" id="app-title-input" placeholder="Ex: Turneul de la Liceu" />
+                        <button onclick="saveAppTitle()" class="btn btn-secondary">💾 Salvează</button>
+                    </div>
+                    <p class="form-hint">Titlul va apărea în antet și în bara de titlu a browserului.</p>
+                    <p id="app-title-feedback" class="form-feedback" role="status" aria-live="polite"></p>
                 </div>
 
                 <div class="form-group">

--- a/script.js
+++ b/script.js
@@ -5,6 +5,80 @@ let liveTimerInterval = null;
 let lastStandings = [];
 let lastStatsData = { teams: [], matches: [] };
 
+const APP_TITLE_STORAGE_KEY = 'tournament_app_title';
+const DEFAULT_APP_TITLE = '🏐 Manager Turneu Volei';
+
+function getStoredAppTitle() {
+    try {
+        const storedTitle = localStorage.getItem(APP_TITLE_STORAGE_KEY);
+        if (storedTitle && storedTitle.trim()) {
+            return storedTitle.trim();
+        }
+    } catch (error) {
+        console.warn('Nu am putut accesa titlul salvat:', error);
+    }
+    return DEFAULT_APP_TITLE;
+}
+
+function applyAppTitle(title) {
+    const sanitizedTitle = title && title.trim() ? title.trim() : DEFAULT_APP_TITLE;
+    const heading = document.getElementById('app-title');
+
+    if (heading) {
+        heading.textContent = sanitizedTitle;
+    }
+
+    document.title = sanitizedTitle;
+}
+
+function initializeAppTitle() {
+    const storedTitle = getStoredAppTitle();
+    applyAppTitle(storedTitle);
+
+    const input = document.getElementById('app-title-input');
+    if (input) {
+        input.value = storedTitle;
+    }
+}
+
+function showAppTitleFeedback(message) {
+    const feedback = document.getElementById('app-title-feedback');
+    if (!feedback) return;
+
+    feedback.textContent = message;
+    feedback.classList.add('visible');
+
+    setTimeout(() => {
+        feedback.textContent = '';
+        feedback.classList.remove('visible');
+    }, 2500);
+}
+
+function saveAppTitle() {
+    const input = document.getElementById('app-title-input');
+    if (!input) return;
+
+    const value = input.value.trim();
+    const finalTitle = value || DEFAULT_APP_TITLE;
+
+    try {
+        localStorage.setItem(APP_TITLE_STORAGE_KEY, finalTitle);
+    } catch (error) {
+        console.warn('Nu am putut salva titlul personalizat:', error);
+    }
+
+    applyAppTitle(finalTitle);
+    input.value = finalTitle;
+    showAppTitleFeedback('Titlul a fost salvat!');
+}
+
+function handleAppTitleKeydown(event) {
+    if (event.key === 'Enter') {
+        event.preventDefault();
+        saveAppTitle();
+    }
+}
+
 function stopLiveTimers() {
     if (liveTimerInterval) {
         clearInterval(liveTimerInterval);
@@ -98,6 +172,13 @@ function durationAttributes(info) {
 
 // Inițializare după încărcarea paginii
 document.addEventListener('DOMContentLoaded', () => {
+    initializeAppTitle();
+
+    const titleInput = document.getElementById('app-title-input');
+    if (titleInput) {
+        titleInput.addEventListener('keydown', handleAppTitleKeydown);
+    }
+
     loadTeams();
     loadMatches();
 });

--- a/styles.css
+++ b/styles.css
@@ -90,6 +90,25 @@ nav {
     gap: 10px;
 }
 
+.form-hint {
+    margin-top: 8px;
+    font-size: 14px;
+    color: #6b7280;
+}
+
+.form-feedback {
+    margin-top: 6px;
+    font-size: 14px;
+    color: #059669;
+    min-height: 20px;
+    transition: opacity 0.2s ease;
+    opacity: 0;
+}
+
+.form-feedback.visible {
+    opacity: 1;
+}
+
 .input-group input {
     flex: 1;
     padding: 12px;
@@ -854,6 +873,35 @@ nav {
     .timeline-sequence {
         --badge-size: clamp(44px, 18vw, 58px);
         grid-template-columns: repeat(auto-fit, minmax(var(--badge-size), 1fr));
+    }
+}
+
+@media (max-width: 600px) {
+    .timeline-sequence {
+        --badge-size: clamp(32px, 16vw, 44px);
+    }
+
+    .point-badge {
+        font-size: 12px;
+    }
+}
+
+@media (max-width: 480px) {
+    .timeline-sequence {
+        --badge-size: clamp(28px, 18vw, 38px);
+    }
+
+    .point-badge {
+        width: var(--badge-size, 28px);
+        height: var(--badge-size, 28px);
+        min-width: var(--badge-size, 28px);
+        font-size: 11px;
+    }
+
+    .team-results-badges .point-badge {
+        min-width: 26px;
+        height: 26px;
+        font-size: 11px;
     }
 }
 


### PR DESCRIPTION
## Summary
- allow the tournament manager title to be customised from the setup view and persist locally
- provide user feedback when saving the title and apply supporting form styles
- shrink point badges on small screens for better readability on phones

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68e4d2466c0883298ecb348d07cd16d9