### PR TITLE
Adjust mobile timeline badges

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -879,6 +879,10 @@ nav {
 @media (max-width: 600px) {
     .timeline-sequence {
         --badge-size: clamp(32px, 16vw, 44px);
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 10px;
     }
 
     .point-badge {
@@ -889,6 +893,10 @@ nav {
 @media (max-width: 480px) {
     .timeline-sequence {
         --badge-size: clamp(28px, 18vw, 38px);
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 8px;
     }
 
     .point-badge {


### PR DESCRIPTION
## Summary
- keep the point timeline badges circular on narrow screens by switching to a wrapping flex layout
- center and space badges consistently on phones while preserving existing sizing clamps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e953f9988329ae420bd4cdafbbb5