### PR TITLE
Add admin authentication and restrict management access

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -3,7 +3,52 @@ require_once 'functions.php';
 
 $action = $_POST['action'] ?? $_GET['action'] ?? '';
 
+$adminActions = [
+    'add_team',
+    'delete_team',
+    'generate_matches',
+    'update_match_order',
+    'start_match',
+    'add_point',
+    'remove_last_point'
+];
+
+if (in_array($action, $adminActions, true) && !isAdmin()) {
+    jsonResponse([
+        'success' => false,
+        'message' => 'Autentificare de administrator necesară pentru această acțiune.',
+        'error' => 'unauthorized'
+    ]);
+}
+
 switch($action) {
+    case 'login':
+        $username = trim($_POST['username'] ?? '');
+        $password = $_POST['password'] ?? '';
+
+        if ($username === '' || $password === '') {
+            jsonResponse([
+                'success' => false,
+                'message' => 'Completează utilizatorul și parola.'
+            ]);
+        }
+
+        $result = loginUser($username, $password);
+        jsonResponse($result);
+        break;
+
+    case 'logout':
+        logoutUser();
+        jsonResponse(['success' => true]);
+        break;
+
+    case 'get_current_user':
+        jsonResponse([
+            'success' => true,
+            'user' => getCurrentUser()
+        ]);
+        break;
+
     case 'add_team':
         $name = trim($_POST['name'] ?? '');
         if ($name) {

--- a/config.php
+++ b/config.php
@@ -23,6 +23,54 @@ try {
     die("Eroare conexiune: " . $e->getMessage());
 }
 
+// Inițializează infrastructura de autentificare
+function initializeAuthentication(PDO $pdo): void {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS users (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        username VARCHAR(100) NOT NULL UNIQUE,
+        password_hash VARCHAR(255) NOT NULL,
+        role VARCHAR(50) NOT NULL DEFAULT 'user',
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
+    $stmt->execute(['admin']);
+
+    if ((int)$stmt->fetchColumn() === 0) {
+        $passwordHash = password_hash('admin123', PASSWORD_DEFAULT);
+        $insert = $pdo->prepare("INSERT INTO users (username, password_hash, role) VALUES (?, ?, 'admin')");
+        $insert->execute(['admin', $passwordHash]);
+    }
+}
+
+initializeAuthentication($pdo);
+
+function setUserSession(array $user): void {
+    $_SESSION['user_id'] = (int)$user['id'];
+    $_SESSION['username'] = $user['username'];
+    $_SESSION['role'] = $user['role'];
+}
+
+function clearUserSession(): void {
+    unset($_SESSION['user_id'], $_SESSION['username'], $_SESSION['role']);
+}
+
+function getCurrentUser(): ?array {
+    if (!isset($_SESSION['user_id'], $_SESSION['username'], $_SESSION['role'])) {
+        return null;
+    }
+
+    return [
+        'id' => (int)$_SESSION['user_id'],
+        'username' => (string)$_SESSION['username'],
+        'role' => (string)$_SESSION['role']
+    ];
+}
+
+function isAdmin(): bool {
+    return isset($_SESSION['role']) && $_SESSION['role'] === 'admin';
+}
+
 // Funcție pentru mesaje JSON
 function jsonResponse($data) {
     header('Content-Type: application/json');

--- a/database.sql
+++ b/database.sql
@@ -2,6 +2,18 @@ CREATE DATABASE IF NOT EXISTS volei_turneu CHARACTER SET utf8mb4 COLLATE utf8mb4
 
 USE volei_turneu;
 
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(100) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    role VARCHAR(50) NOT NULL DEFAULT 'user',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO users (username, password_hash, role)
+SELECT 'admin', '$2y$12$oblL2U3fI8.q3/TrB6H2.uaWMVzdTxWEOJzNjFzyVx9fOlf39h4Rq', 'admin'
+WHERE NOT EXISTS (SELECT 1 FROM users WHERE username = 'admin');
+
 CREATE TABLE teams (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL,

--- a/index.php
+++ b/index.php
@@ -1,4 +1,10 @@
-<?php require_once 'functions.php'; ?>
+<?php
+require_once 'functions.php';
+
+$currentUser = getCurrentUser();
+$isAdmin = $currentUser && ($currentUser['role'] ?? '') === 'admin';
+$defaultView = $isAdmin ? 'setup' : 'matches';
+?>
 <!DOCTYPE html>
 <html lang="ro">
 <head>
@@ -7,21 +13,39 @@
     <title>Manager Turneu Volei</title>
     <link rel="stylesheet" href="styles.css">
 </head>
-<body>
+<body data-is-admin="<?= $isAdmin ? '1' : '0' ?>">
     <div class="container">
         <header>
             <h1 id="app-title">🏐 Manager Turneu Volei</h1>
             <nav>
-                <button class="nav-btn active" data-view="setup">⚙️ Setup</button>
-                <button class="nav-btn" data-view="matches">📋 Meciuri</button>
-                <button class="nav-btn" data-view="live">⚡ Meci Live</button>
-                <button class="nav-btn" data-view="standings">🏆 Clasament</button>
-                <button class="nav-btn" data-view="stats">📊 Statistici</button>
+                <?php if ($isAdmin): ?>
+                    <button class="nav-btn <?= $defaultView === 'setup' ? 'active' : '' ?>" data-view="setup">⚙️ Setup</button>
+                <?php endif; ?>
+                <button class="nav-btn <?= $defaultView === 'matches' ? 'active' : '' ?>" data-view="matches">📋 Meciuri</button>
+                <button class="nav-btn <?= $defaultView === 'live' ? 'active' : '' ?>" data-view="live">⚡ Meci Live</button>
+                <button class="nav-btn <?= $defaultView === 'standings' ? 'active' : '' ?>" data-view="standings">🏆 Clasament</button>
+                <button class="nav-btn <?= $defaultView === 'stats' ? 'active' : '' ?>" data-view="stats">📊 Statistici</button>
             </nav>
+            <div class="auth-bar">
+                <?php if ($currentUser): ?>
+                    <span class="auth-status">Autentificat ca <strong><?= htmlspecialchars($currentUser['username'], ENT_QUOTES, 'UTF-8') ?></strong> (<?= htmlspecialchars($currentUser['role'], ENT_QUOTES, 'UTF-8') ?>)</span>
+                    <button id="logout-button" class="btn btn-secondary auth-button" type="button">🔓 Deconectare</button>
+                <?php else: ?>
+                    <form id="login-form" class="auth-form" autocomplete="off">
+                        <label class="sr-only" for="login-username">Utilizator</label>
+                        <input id="login-username" name="username" type="text" placeholder="Utilizator" required>
+                        <label class="sr-only" for="login-password">Parolă</label>
+                        <input id="login-password" name="password" type="password" placeholder="Parolă" required>
+                        <button type="submit" class="btn btn-primary auth-button">🔐 Autentificare</button>
+                    </form>
+                    <p id="login-feedback" class="auth-feedback" role="status" aria-live="polite"></p>
+                <?php endif; ?>
+            </div>
         </header>
 
         <!-- VIEW: SETUP -->
-        <div id="view-setup" class="view active">
+        <?php if ($isAdmin): ?>
+        <div id="view-setup" class="view <?= $defaultView === 'setup' ? 'active' : '' ?>">
             <div class="card">
                 <h2>Configurare Turneu</h2>
                 
@@ -61,18 +85,23 @@
                 </button>
             </div>
         </div>
+        <?php endif; ?>
 
         <!-- VIEW: MATCHES -->
-        <div id="view-matches" class="view">
+        <div id="view-matches" class="view <?= $defaultView === 'matches' ? 'active' : '' ?>">
             <div class="card">
                 <h2>Program Meciuri</h2>
-                <p class="info">💡 Poți modifica ordinea meciurilor folosind săgețile</p>
+                <?php if ($isAdmin): ?>
+                    <p class="info">💡 Poți modifica ordinea meciurilor folosind săgețile</p>
+                <?php else: ?>
+                    <p class="info">ℹ️ Programul este gestionat de administrator. Poți urmări meciurile programate mai jos.</p>
+                <?php endif; ?>
                 <div id="matches-list"></div>
             </div>
         </div>
 
         <!-- VIEW: LIVE -->
-        <div id="view-live" class="view">
+        <div id="view-live" class="view <?= $defaultView === 'live' ? 'active' : '' ?>">
             <div class="card">
                 <div id="live-match-container">
                     <p class="text-center">Selectează un meci din lista de meciuri pentru a începe</p>
@@ -81,7 +110,7 @@
         </div>
 
         <!-- VIEW: STANDINGS -->
-        <div id="view-standings" class="view">
+        <div id="view-standings" class="view <?= $defaultView === 'standings' ? 'active' : '' ?>">
             <div class="card">
                 <h2>🏆 Clasament General</h2>
                 <div class="standings-actions">
@@ -106,7 +135,7 @@
         </div>
 
         <!-- VIEW: STATS -->
-        <div id="view-stats" class="view">
+        <div id="view-stats" class="view <?= $defaultView === 'stats' ? 'active' : '' ?>">
             <div class="card">
                 <h2>📊 Statistici Detaliate</h2>
                 <div class="stats-actions">

--- a/styles.css
+++ b/styles.css
@@ -47,6 +47,78 @@ nav {
     flex-wrap: wrap;
 }
 
+.auth-bar {
+    margin-top: 15px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: flex-end;
+    align-items: center;
+}
+
+.auth-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.auth-form input {
+    padding: 10px 14px;
+    border: 2px solid rgba(59, 130, 246, 0.4);
+    border-radius: 8px;
+    font-size: 15px;
+    background-color: #fff;
+    min-width: 140px;
+}
+
+.auth-form input:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.auth-status {
+    color: #1f2937;
+    font-weight: 600;
+}
+
+.auth-button {
+    white-space: nowrap;
+}
+
+.auth-feedback {
+    width: 100%;
+    text-align: right;
+    font-size: 14px;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.auth-feedback.visible {
+    opacity: 1;
+}
+
+.auth-feedback-error {
+    color: #dc2626;
+}
+
+.auth-feedback-success {
+    color: #059669;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .nav-btn {
     padding: 10px 20px;
     border: 2px solid rgba(59, 130, 246, 0.4);


### PR DESCRIPTION
## Summary
- introduce a users table, default admin seeding, and helper utilities so administrators can authenticate and manage the tournament
- add login/logout AJAX endpoints and protect existing modifying routes so that only administrators can generate matches or update live scores
- update the frontend to show a login form, hide the setup view for guests, guard client actions, and style the new authentication controls

## Testing
- php -l Scor/config.php
- php -l Scor/functions.php
- php -l Scor/ajax.php
- php -l Scor/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e4f998e99c8329ba79269b60275da3