### PR TITLE
Fix authentication by preventing premature output in PHP files

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -141,4 +141,3 @@ switch($action) {
     default:
         jsonResponse(['success' => false, 'message' => 'Acțiune invalidă']);
 }
-?>

--- a/config.php
+++ b/config.php
@@ -81,5 +81,3 @@ function jsonResponse($data) {
     echo json_encode($data);
     exit;
 }
-
-?>

--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,3 @@
-
 <?php
 require_once 'config.php';
 
@@ -660,4 +659,3 @@ function getMatchesWithHistory() {
 
     return $result;
 }
-?>


### PR DESCRIPTION
## Summary
- remove the leading newline before the PHP opening tag in `functions.php` so no output is sent before the session starts
- drop the closing PHP tags from the PHP-only entry points to avoid accidental whitespace that prevents sessions from being created

## Testing
- php -l ajax.php
- php -l config.php
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68e60a95bbf08329a49cebe9e2f3ff07