### PR TITLE
Adjust admin authentication alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -392,7 +392,7 @@ nav {
     margin-top: 1.5rem;
     display: flex;
     gap: 1rem;
-    justify-content: flex-end;
+    justify-content: flex-start;
     align-items: center;
 }
 
@@ -426,7 +426,7 @@ nav {
 .auth-panel {
     position: absolute;
     top: calc(100% + 0.75rem);
-    right: 0;
+    left: 0;
     width: 320px;
     padding: 1.5rem;
     background: white;


### PR DESCRIPTION
## Summary
- align the admin authentication bar to the left side of the header so the login fields remain visible
- reposition the dropdown panel to open from the left edge to match the new alignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e61165fa188329b154cc13215df3a4