### PR TITLE
Move admin authentication controls above header

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,6 +14,41 @@ $isAdmin = isAdmin();
 </head>
 <body data-is-admin="<?= $isAdmin ? '1' : '0' ?>">
     <div class="container">
+        <div class="auth-bar">
+            <?php if ($currentUser): ?>
+                <div class="auth-status-badge" aria-live="polite">
+                    <span class="auth-status-icon" aria-hidden="true">👤</span>
+                    <div class="auth-status-text">
+                        <span class="auth-status-label">Autentificat</span>
+                        <strong><?= htmlspecialchars($currentUser['username'], ENT_QUOTES, 'UTF-8') ?></strong>
+                        <span class="auth-status-role"><?= htmlspecialchars($currentUser['role'], ENT_QUOTES, 'UTF-8') ?></span>
+                    </div>
+                </div>
+                <button id="logout-button" class="btn btn-secondary auth-button" type="button">🔓 Deconectare</button>
+            <?php else: ?>
+                <div class="auth-dropdown">
+                    <button id="auth-toggle" class="auth-toggle" type="button" aria-haspopup="true" aria-expanded="false">
+                        <span class="auth-toggle-icon" aria-hidden="true">🔐</span>
+                        <span class="auth-toggle-text">Autentificare Admin</span>
+                    </button>
+                    <div id="auth-panel" class="auth-panel" role="dialog" aria-modal="false" aria-hidden="true">
+                        <form id="login-form" class="auth-form" autocomplete="off">
+                            <div class="auth-form-group">
+                                <label for="login-username">Utilizator</label>
+                                <input id="login-username" name="username" type="text" placeholder="Ex: admin" required>
+                            </div>
+                            <div class="auth-form-group">
+                                <label for="login-password">Parolă</label>
+                                <input id="login-password" name="password" type="password" placeholder="Parolă" required>
+                            </div>
+                            <button type="submit" class="btn btn-primary auth-button btn-full">Autentifică-te</button>
+                        </form>
+                        <p id="login-feedback" class="auth-feedback" role="status" aria-live="polite"></p>
+                        <p class="auth-hint">Cont implicit: <strong>admin</strong> / <strong>admin123</strong></p>
+                    </div>
+                </div>
+            <?php endif; ?>
+        </div>
         <header>
             <h1 id="app-title">🏐 Manager Turneu Volei</h1>
             <nav>
@@ -25,41 +60,6 @@ $isAdmin = isAdmin();
                     <button class="nav-btn nav-btn-admin" data-view="admin">⚙️ Administrare</button>
                 <?php endif; ?>
             </nav>
-            <div class="auth-bar">
-                <?php if ($currentUser): ?>
-                    <div class="auth-status-badge" aria-live="polite">
-                        <span class="auth-status-icon" aria-hidden="true">👤</span>
-                        <div class="auth-status-text">
-                            <span class="auth-status-label">Autentificat</span>
-                            <strong><?= htmlspecialchars($currentUser['username'], ENT_QUOTES, 'UTF-8') ?></strong>
-                            <span class="auth-status-role"><?= htmlspecialchars($currentUser['role'], ENT_QUOTES, 'UTF-8') ?></span>
-                        </div>
-                    </div>
-                    <button id="logout-button" class="btn btn-secondary auth-button" type="button">🔓 Deconectare</button>
-                <?php else: ?>
-                    <div class="auth-dropdown">
-                        <button id="auth-toggle" class="auth-toggle" type="button" aria-haspopup="true" aria-expanded="false">
-                            <span class="auth-toggle-icon" aria-hidden="true">🔐</span>
-                            <span class="auth-toggle-text">Autentificare Admin</span>
-                        </button>
-                        <div id="auth-panel" class="auth-panel" role="dialog" aria-modal="false" aria-hidden="true">
-                            <form id="login-form" class="auth-form" autocomplete="off">
-                                <div class="auth-form-group">
-                                    <label for="login-username">Utilizator</label>
-                                    <input id="login-username" name="username" type="text" placeholder="Ex: admin" required>
-                                </div>
-                                <div class="auth-form-group">
-                                    <label for="login-password">Parolă</label>
-                                    <input id="login-password" name="password" type="password" placeholder="Parolă" required>
-                                </div>
-                                <button type="submit" class="btn btn-primary auth-button btn-full">Autentifică-te</button>
-                            </form>
-                            <p id="login-feedback" class="auth-feedback" role="status" aria-live="polite"></p>
-                            <p class="auth-hint">Cont implicit: <strong>admin</strong> / <strong>admin123</strong></p>
-                        </div>
-                    </div>
-                <?php endif; ?>
-            </div>
         </header>
 
         <!-- VIEW: MATCHES (Public) -->

--- a/styles.css
+++ b/styles.css
@@ -389,11 +389,12 @@ nav {
 
 /* AUTH BAR - Design elegant */
 .auth-bar {
-    margin-top: 1.5rem;
     display: flex;
-    gap: 1rem;
-    justify-content: flex-start;
+    justify-content: flex-end;
     align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
 }
 
 .auth-dropdown {
@@ -2033,9 +2034,13 @@ nav {
     body {
         padding: 1rem;
     }
-    
+
     header {
         padding: 1.5rem 1.25rem;
+    }
+
+    .auth-bar {
+        justify-content: center;
     }
     
     header h1 {


### PR DESCRIPTION
## Summary
- move the admin authentication controls above the main header so they appear at the top of the page
- update styling to right-align the auth bar by default and center it on smaller screens

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68e61531ef34832980495d9cb2a86c7d