### PR TITLE
Add admin password reset interface and hide default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Accesează: `http://localhost/Scor`
 
 **Cont implicit administrator:**
 - Utilizator: `admin`
-- Parolă: `admin123`
+- Parola inițială este definită în `config.php` și ar trebui schimbată imediat din panoul de administrare.
 
 ## 🌐 Deployment pe Hosting
 
@@ -100,7 +100,7 @@ define('DB_NAME', 'nume_baza_date');
 ### 4. Verificare Funcționalitate
 
 1. Accesează domeniul în browser
-2. Autentifică-te cu `admin` / `admin123`
+2. Autentifică-te cu utilizatorul implicit și parola configurată (vezi `config.php`)
 3. Testează adăugarea unei echipe
 4. Generează meciuri de probă
 
@@ -108,17 +108,19 @@ define('DB_NAME', 'nume_baza_date');
 
 ### Schimbare Parolă Administrator
 
-1. Generează hash nou:
+Din panoul **Administrare → Administrare cont** poți actualiza parola administratorului furnizând parola curentă și una nouă (minim 8 caractere). După salvare, toate sesiunile active vor folosi noua parolă.
+
+Pentru scenarii în care nu mai cunoști parola curentă, poți genera manual un hash nou și actualiza direct baza de date:
+
 ```php
 <?php
 echo password_hash('parola_noua', PASSWORD_DEFAULT);
 ?>
 ```
 
-2. Actualizează în baza de date:
 ```sql
-UPDATE users 
-SET password_hash = 'hash_generat_mai_sus' 
+UPDATE users
+SET password_hash = 'hash_generat_mai_sus'
 WHERE username = 'admin';
 ```
 

--- a/ajax.php
+++ b/ajax.php
@@ -10,7 +10,8 @@ $adminActions = [
     'update_match_order',
     'start_match',
     'add_point',
-    'remove_last_point'
+    'remove_last_point',
+    'change_password'
 ];
 
 if (in_array($action, $adminActions, true) && !isAdmin()) {
@@ -40,6 +41,38 @@ switch($action) {
     case 'logout':
         logoutUser();
         jsonResponse(['success' => true]);
+        break;
+
+    case 'change_password':
+        $currentPassword = $_POST['current_password'] ?? '';
+        $newPassword = $_POST['new_password'] ?? '';
+        $confirmPassword = $_POST['confirm_password'] ?? '';
+
+        if ($currentPassword === '' || $newPassword === '' || $confirmPassword === '') {
+            jsonResponse([
+                'success' => false,
+                'message' => 'Completează toate câmpurile.'
+            ]);
+        }
+
+        if ($newPassword !== $confirmPassword) {
+            jsonResponse([
+                'success' => false,
+                'message' => 'Parola nouă și confirmarea nu coincid.'
+            ]);
+        }
+
+        $currentUser = getCurrentUser();
+        if (!$currentUser) {
+            jsonResponse([
+                'success' => false,
+                'message' => 'Autentificare necesară.',
+                'error' => 'unauthorized'
+            ]);
+        }
+
+        $result = changeUserPassword((int)$currentUser['id'], $currentPassword, $newPassword);
+        jsonResponse($result);
         break;
 
     case 'get_current_user':

--- a/index.php
+++ b/index.php
@@ -44,7 +44,6 @@ $isAdmin = isAdmin();
                             <button type="submit" class="btn btn-primary auth-button btn-full">Autentifică-te</button>
                         </form>
                         <p id="login-feedback" class="auth-feedback" role="status" aria-live="polite"></p>
-                        <p class="auth-hint">Cont implicit: <strong>admin</strong> / <strong>admin123</strong></p>
                     </div>
                 </div>
             <?php endif; ?>
@@ -130,6 +129,26 @@ $isAdmin = isAdmin();
             <div class="card">
                 <h2>⚙️ Panou de Administrare</h2>
                 
+                <div class="admin-section">
+                    <h3>🔑 Administrare cont</h3>
+                    <form id="password-change-form" class="auth-form" autocomplete="off">
+                        <div class="auth-form-group">
+                            <label for="current-password">Parolă curentă</label>
+                            <input id="current-password" name="current_password" type="password" placeholder="Parola actuală" required>
+                        </div>
+                        <div class="auth-form-group">
+                            <label for="new-password">Parolă nouă</label>
+                            <input id="new-password" name="new_password" type="password" placeholder="Minim 8 caractere" required>
+                        </div>
+                        <div class="auth-form-group">
+                            <label for="confirm-password">Confirmă parola</label>
+                            <input id="confirm-password" name="confirm_password" type="password" placeholder="Repetă parola nouă" required>
+                        </div>
+                        <button type="submit" class="btn btn-secondary auth-button btn-full">💾 Salvează parola</button>
+                    </form>
+                    <p id="password-change-feedback" class="auth-feedback" role="status" aria-live="polite"></p>
+                </div>
+
                 <div class="admin-section">
                     <h3>🎨 Configurare Aplicație</h3>
                     <div class="form-group">


### PR DESCRIPTION
## Summary
- add an administrator account management section with a password change form in the admin panel
- implement backend support for secure password updates and hide hard-coded credentials from the UI and docs
- refresh documentation to explain the new password workflow

## Testing
- php -l index.php
- php -l ajax.php
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68e61afaae7483298340e705246bf14c