### PR TITLE
Add admin live timeline view

### DIFF
--- a/index.php
+++ b/index.php
@@ -332,6 +332,14 @@ $isAdmin = isAdmin();
     margin-top: 12px;
 }
 
+.points-timeline.admin-live-timeline {
+    margin-top: 24px;
+}
+
+.points-timeline.admin-live-timeline h3 {
+    font-size: 1.25rem;
+}
+
 @media (max-width: 768px) {
     .admin-match-item {
         flex-direction: column;


### PR DESCRIPTION
## Summary
- add a shared helper that renders the detailed points timeline for a match
- show the same timeline and improved status messaging inside the admin live control panel
- reuse the helper in the public live match view and tweak admin timeline styling

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68e625a33d4c832994e0e6d87b9f8582