### PR TITLE
Improve mobile layout for standings table

### DIFF
--- a/script.js
+++ b/script.js
@@ -1038,25 +1038,25 @@ function loadStandings() {
                                 const formatDiff = value => value > 0 ? `+${value}` : value === 0 ? '0' : `${value}`;
                                 return `
                                     <tr class="standings-row ${medalClass}">
-                                        <td class="standings-rank"><span class="rank-badge">#${rank}</span></td>
-                                        <td class="standings-team"><span class="team-name">${team.name}</span></td>
-                                        <td class="standings-points"><span class="points-pill">${team.ranking_points} pct</span></td>
-                                        <td>${team.wins}</td>
-                                        <td>${team.losses}</td>
-                                        <td>
+                                        <td class="standings-rank" data-label="Loc"><span class="rank-badge">#${rank}</span></td>
+                                        <td class="standings-team" data-label="Echipă"><span class="team-name">${team.name}</span></td>
+                                        <td class="standings-points" data-label="Puncte clasament"><span class="points-pill">${team.ranking_points} pct</span></td>
+                                        <td data-label="Victorii">${team.wins}</td>
+                                        <td data-label="Înfrângeri">${team.losses}</td>
+                                        <td data-label="Seturi (+/-)">
                                             <div class="stat-line">
                                                 <span class="stat-line-main">${team.sets_won}-${team.sets_lost}</span>
                                                 <span class="stat-line-diff ${setsDiff > 0 ? 'positive' : setsDiff < 0 ? 'negative' : ''}">${formatDiff(setsDiff)}</span>
                                             </div>
                                         </td>
-                                        <td>${team.set_ratio_display}</td>
-                                        <td>
+                                        <td data-label="Raport seturi">${team.set_ratio_display}</td>
+                                        <td data-label="Puncte (+/-)">
                                             <div class="stat-line">
                                                 <span class="stat-line-main">${team.points_won}-${team.points_lost}</span>
                                                 <span class="stat-line-diff ${pointsDiff > 0 ? 'positive' : pointsDiff < 0 ? 'negative' : ''}">${formatDiff(pointsDiff)}</span>
                                             </div>
                                         </td>
-                                        <td>${team.point_ratio_display}</td>
+                                        <td data-label="Raport puncte">${team.point_ratio_display}</td>
                                     </tr>
                                 `;
                             }).join('')}

--- a/styles.css
+++ b/styles.css
@@ -2110,25 +2110,97 @@ nav {
     nav {
         gap: 0.375rem;
     }
-    
+
     .nav-btn {
         padding: 0.625rem 1rem;
         font-size: 0.875rem;
     }
-    
+
     .stats-grid {
         grid-template-columns: 1fr;
     }
-    
+
     .team-stats-grid {
         grid-template-columns: 1fr;
     }
-    
+
     .standings-table-wrapper {
-        overflow-x: auto;
+        overflow: visible;
     }
-    
-    .standings-table table {
-        min-width: 800px;
+
+    .standings-table table,
+    .standings-table tbody,
+    .standings-table tr,
+    .standings-table td {
+        display: block;
+        width: 100%;
+    }
+
+    .standings-table thead {
+        display: none;
+    }
+
+    .standings-table tbody tr {
+        margin-bottom: 1.25rem;
+        padding: 1.125rem 1.25rem;
+        border: 1px solid var(--gray-200);
+        border-radius: var(--radius-xl);
+        box-shadow: var(--shadow-sm);
+        background: white;
+    }
+
+    .standings-gold,
+    .standings-silver,
+    .standings-bronze {
+        border-left-width: 0;
+    }
+
+    .standings-row {
+        transform: none !important;
+    }
+
+    .standings-table tbody td {
+        padding: 0.5rem 0;
+        border-bottom: none;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+    }
+
+    .standings-table tbody td::before {
+        content: attr(data-label);
+        font-weight: 600;
+        text-transform: uppercase;
+        color: var(--gray-600);
+        font-size: 0.75rem;
+        letter-spacing: 0.04em;
+    }
+
+    .standings-table tbody td:last-child {
+        border-bottom: none;
+    }
+
+    .standings-rank,
+    .standings-team,
+    .standings-points {
+        width: 100%;
+    }
+
+    .rank-badge {
+        width: 40px;
+        height: 40px;
+        font-size: 1rem;
+        margin-left: auto;
+    }
+
+    .points-pill {
+        margin-left: auto;
+    }
+
+    .stat-line {
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.25rem;
     }
 }


### PR DESCRIPTION
## Summary
- add descriptive data-label attributes to each standings table cell so headers remain visible on mobile
- redesign the standings table styles under 640px to render as stacked cards without horizontal scrolling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e6351106288329832719040ce74bdf