### PR TITLE
Adjust live scoreboard team name sizing

### DIFF
--- a/script.js
+++ b/script.js
@@ -936,6 +936,16 @@ function loadLiveMatch() {
         });
 }
 
+function getAdaptiveTeamNameClass(name) {
+    if (!name) return '';
+    const trimmed = name.trim();
+    const length = trimmed.length;
+    if (length > 28) return 'team-name--xsmall';
+    if (length > 20) return 'team-name--small';
+    if (length > 14) return 'team-name--medium';
+    return '';
+}
+
 function renderLiveMatch(data) {
     const { match, sets = [], points = [] } = data;
     const container = document.getElementById('live-match-container');
@@ -987,6 +997,8 @@ function renderLiveMatch(data) {
         currentSetNumber,
         emptyMessage: 'Nu există date pentru acest meci.'
     });
+    const team1NameClass = getAdaptiveTeamNameClass(match.team1_name);
+    const team2NameClass = getAdaptiveTeamNameClass(match.team2_name);
     const scoreboard = `
         <div class="scoreboard">
             <div class="scoreboard-header">
@@ -1009,13 +1021,13 @@ function renderLiveMatch(data) {
             <div class="scoreboard-main">
                 <div class="team-card team1 ${team1Winner ? 'winner' : ''}">
                     ${team1WinnerTag}
-                    <div class="team-name">${match.team1_name}</div>
+                    <div class="team-name ${team1NameClass}">${match.team1_name}</div>
                     <div class="team-points">${currentPointsTeam1}</div>
                     <div class="team-meta">${pointsLabel}</div>
                 </div>
                 <div class="team-card team2 ${team2Winner ? 'winner' : ''}">
                     ${team2WinnerTag}
-                    <div class="team-name">${match.team2_name}</div>
+                    <div class="team-name ${team2NameClass}">${match.team2_name}</div>
                     <div class="team-points">${currentPointsTeam2}</div>
                     <div class="team-meta">${pointsLabel}</div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -1126,6 +1126,21 @@ nav {
     font-weight: 800;
     letter-spacing: -0.01em;
     text-transform: uppercase;
+    text-align: center;
+    line-height: 1.15;
+    word-break: break-word;
+}
+
+.team-card .team-name.team-name--medium {
+    font-size: 1.35rem;
+}
+
+.team-card .team-name.team-name--small {
+    font-size: 1.2rem;
+}
+
+.team-card .team-name.team-name--xsmall {
+    font-size: 1.05rem;
 }
 
 .team-card .team-points {


### PR DESCRIPTION
## Summary
- add a helper that assigns adaptive size classes to live scoreboard team names so long names shrink without altering score size
- extend scoreboard styles to center team names and provide smaller size tiers for long labels

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ec960fd62c8329a3cf88386f607432