### PR TITLE
Add mobile quick action buttons for public sections

### DIFF
--- a/index.php
+++ b/index.php
@@ -59,6 +59,17 @@ $isAdmin = isAdmin();
                     <button class="nav-btn nav-btn-admin" data-view="admin">⚙️ Administrare</button>
                 <?php endif; ?>
             </nav>
+            <div class="mobile-quick-actions" aria-label="Navigare rapidă">
+                <button type="button" class="mobile-quick-action" data-view="live">
+                    ⚡ Meci Live
+                </button>
+                <button type="button" class="mobile-quick-action" data-view="standings">
+                    🏆 Clasament
+                </button>
+                <button type="button" class="mobile-quick-action" data-view="stats">
+                    📊 Statistici
+                </button>
+            </div>
         </header>
 
         <!-- VIEW: MATCHES (Public) -->

--- a/script.js
+++ b/script.js
@@ -451,6 +451,12 @@ document.querySelectorAll('.nav-btn').forEach(btn => {
     });
 });
 
+document.querySelectorAll('.mobile-quick-action').forEach(btn => {
+    btn.addEventListener('click', function() {
+        switchView(this.dataset.view);
+    });
+});
+
 function switchView(view) {
     currentView = view;
     document.querySelectorAll('.nav-btn').forEach(btn => {
@@ -458,6 +464,9 @@ function switchView(view) {
         if (btn.dataset.view === view) {
             btn.classList.add('active');
         }
+    });
+    document.querySelectorAll('.mobile-quick-action').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.view === view);
     });
     document.querySelectorAll('.view').forEach(v => {
         v.classList.remove('active');

--- a/styles.css
+++ b/styles.css
@@ -195,6 +195,45 @@ nav {
     border-bottom: 3px solid transparent;
 }
 
+.mobile-quick-actions {
+    display: none;
+}
+
+.mobile-quick-action {
+    border: none;
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius-xl);
+    font-weight: 600;
+    font-size: 0.9375rem;
+    background: white;
+    color: var(--gray-700);
+    box-shadow: var(--shadow-md);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.mobile-quick-action:hover,
+.mobile-quick-action:focus {
+    background: var(--primary-50);
+    color: var(--primary-700);
+    transform: translateY(-1px);
+}
+
+.mobile-quick-action:focus-visible {
+    outline: 2px solid var(--primary-500);
+    outline-offset: 2px;
+}
+
+.mobile-quick-action.active {
+    background: linear-gradient(135deg, var(--primary-600), var(--primary-500));
+    color: white;
+    box-shadow: var(--shadow-lg);
+}
+
 .nav-btn::before {
     content: '';
     position: absolute;
@@ -2056,6 +2095,18 @@ nav {
 
     header {
         padding: 1.5rem 1.25rem;
+    }
+
+    .mobile-quick-actions {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 0.75rem;
+        margin-top: 1rem;
+    }
+
+    .mobile-quick-action {
+        font-size: 0.875rem;
+        padding: 0.75rem;
     }
 
     .auth-bar {


### PR DESCRIPTION
## Summary
- add a mobile-only quick actions strip so visitors can open Live, Clasament or Statistici without logging in
- hook the new buttons into the existing view switcher and styling, including active state sync and focus outlines
- style the quick actions for small screens to fit the responsive layout

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ec9d39d1148329b00495ebd11dea12